### PR TITLE
updated invalid url for disabling bfcache with RelatedActiveContentsExist

### DIFF
--- a/source/_posts/2022/11-18-seccon-en.md
+++ b/source/_posts/2022/11-18-seccon-en.md
@@ -1166,7 +1166,7 @@ Firstly, you have to disable bfcache[^spanote-1]. There are many conditions wher
 The easy way is to use `RelatedActiveContentsExist`.
 
 - `RelatedActiveContentsExist`: The page opend with `window.open()` and it has a reference of `window.opener`.
-- ref. https://web.dev/articles/bfcache#avoid_windowopener_references
+- ref. https://web.dev/articles/bfcache?hl=en#avoid_windowopener_references
 
 [^spanote-1]: In fact, you can skip this step because bfcache is disabled by [default options](https://github.com/puppeteer/puppeteer/blob/v19.2.0/packages/puppeteer-core/src/node/ChromeLauncher.ts#L175) of puppeteer.
 
@@ -1352,7 +1352,7 @@ Example payload:
         // Access to the deleted page again using History API
         // Then, the browser will render the cached page and the XSS will occur!
         // Note that a bfcache will not be used because the page will have a window.opener reference.
-        //   ref. https://web.dev/articles/bfcache#avoid_windowopener_references
+        //   ref. https://web.dev/articles/bfcache?hl=en#avoid_windowopener_references
         evilWindow.location = `${location.origin}/back.html?n=2`;
       }
       await sleep(1000);

--- a/source/_posts/2022/11-18-seccon-en.md
+++ b/source/_posts/2022/11-18-seccon-en.md
@@ -1166,7 +1166,7 @@ Firstly, you have to disable bfcache[^spanote-1]. There are many conditions wher
 The easy way is to use `RelatedActiveContentsExist`.
 
 - `RelatedActiveContentsExist`: The page opend with `window.open()` and it has a reference of `window.opener`.
-- ref. https://web.dev/i18n/en/bfcache/#avoid-windowopener-references
+- ref. https://web.dev/articles/bfcache#avoid_windowopener_references
 
 [^spanote-1]: In fact, you can skip this step because bfcache is disabled by [default options](https://github.com/puppeteer/puppeteer/blob/v19.2.0/packages/puppeteer-core/src/node/ChromeLauncher.ts#L175) of puppeteer.
 
@@ -1352,7 +1352,7 @@ Example payload:
         // Access to the deleted page again using History API
         // Then, the browser will render the cached page and the XSS will occur!
         // Note that a bfcache will not be used because the page will have a window.opener reference.
-        //   ref. https://web.dev/i18n/en/bfcache/#avoid-windowopener-references
+        //   ref. https://web.dev/articles/bfcache#avoid_windowopener_references
         evilWindow.location = `${location.origin}/back.html?n=2`;
       }
       await sleep(1000);

--- a/source/_posts/2022/11-18-seccon-ja.md
+++ b/source/_posts/2022/11-18-seccon-ja.md
@@ -1238,7 +1238,7 @@ bfcacheが使われない条件はたくさんあり、そのリストはこち�
 
 お手軽なのは`RelatedActiveContentsExist`で、`window.open()`を使って`window.opener`の参照を持つ状態にすることです。これは
 
-- https://web.dev/articles/bfcache#avoid_windowopener_references
+- https://web.dev/articles/bfcache?hl=en#avoid_windowopener_references
 
 でも紹介されています。
 
@@ -1431,7 +1431,7 @@ fastifyの実装を確認すると
         // Access to the deleted page again using History API
         // Then, the browser will render the cached page and the XSS will occur!
         // Note that a bfcache will not be used because the page will have a window.opener reference.
-        //   ref. https://web.dev/articles/bfcache#avoid_windowopener_references
+        //   ref. https://web.dev/articles/bfcache?hl=en#avoid_windowopener_references
         evilWindow.location = `${location.origin}/back.html?n=2`;
       }
       await sleep(1000);

--- a/source/_posts/2022/11-18-seccon-ja.md
+++ b/source/_posts/2022/11-18-seccon-ja.md
@@ -1238,7 +1238,7 @@ bfcacheが使われない条件はたくさんあり、そのリストはこち�
 
 お手軽なのは`RelatedActiveContentsExist`で、`window.open()`を使って`window.opener`の参照を持つ状態にすることです。これは
 
-- https://web.dev/i18n/en/bfcache/#avoid-windowopener-references
+- https://web.dev/articles/bfcache#avoid_windowopener_references
 
 でも紹介されています。
 
@@ -1431,7 +1431,7 @@ fastifyの実装を確認すると
         // Access to the deleted page again using History API
         // Then, the browser will render the cached page and the XSS will occur!
         // Note that a bfcache will not be used because the page will have a window.opener reference.
-        //   ref. https://web.dev/i18n/en/bfcache/#avoid-windowopener-references
+        //   ref. https://web.dev/articles/bfcache#avoid_windowopener_references
         evilWindow.location = `${location.origin}/back.html?n=2`;
       }
       await sleep(1000);


### PR DESCRIPTION
The url does not seem to work anymore, I found https://web.dev/articles/bfcache#avoid_windowopener_references which seems to reference the same thing